### PR TITLE
Proposed fix for issue https://github.com/filoe/cscore/issues/4

### DIFF
--- a/CSCore/Codecs/FLAC/SubFrames/FlacSubFrameBase.cs
+++ b/CSCore/Codecs/FLAC/SubFrames/FlacSubFrameBase.cs
@@ -36,15 +36,16 @@ namespace CSCore.Codecs.FLAC
             {
                 subFrame = new FlacSubFrameVerbatim(reader, header, data, bitsPerSample);
             }
+            else if ((subframeType & 0x20) != 0) //100000 = 0x20
+            {
+                order = (int)(subframeType & 0x1F) + 1;
+                subFrame = new FlacSubFrameLPC(reader, header, data, bitsPerSample, order);
+            }
             else if ((subframeType & 0x08) != 0) //001000 = 0x08
             {
                 order = (int) (subframeType & 0x07);
+                if (order > 4) return null;
                 subFrame = new FlacSubFrameFixed(reader, header, data, bitsPerSample, order);
-            }
-            else if ((subframeType & 0x20) != 0) //100000 = 0x20
-            {
-                order = (int) (subframeType & 0x1F) + 1;
-                subFrame = new FlacSubFrameLPC(reader, header, data, bitsPerSample, order);
             }
             else
             {


### PR DESCRIPTION
This fixes https://github.com/filoe/cscore/issues/4 in the tests I've done.
Looking at https://xiph.org/flac/format.html#subframe_header this avoids the case where an incorrect subframe match will occur for `001xxx : SUBFRAME_FIXED`.

Why this is needed:

Checking `(subframeType & 0x08 != 0)` will match `001xxx (SUBFRAME_FIXED)`, but it will also incorecctly match `xx1xxx (SUBFRAME_LPC)`. 

Since this statement was before the check for `SUBFRAME_LPC, (subframeType & 0x20 != 0)`, certain subframes were incorrectly matched as `SUBFRAME_FIXED`, when they were `SUBRAME_LPC`.

This incorrect matching was fixed by changing the order of the if statements, and checking for `SUBFRAME_LPC` first, and then `SUBFRAME_FIXED`.

Additionally, it is possible for the last 3 bits in `SUBFRAME_FIXED` to be > 4. The FLAC standard requires that the last 3 bits be <= 4 or the subframe is reserved (I presume reserved means does nothing atm?). A check was added to ensure that order <= 4 for `SUBFRAME_FIXED`.

NOTE: The conditional block would make more sense if the order was reversed (i.e. check for `1xxxxx`, then `01xxxx`, `001xxx`, etc)