### PR TITLE
Fixed typo in 'WasapiCapture' class

### DIFF
--- a/CSCore/SoundIn/WasapiCapture.cs
+++ b/CSCore/SoundIn/WasapiCapture.cs
@@ -318,7 +318,7 @@ namespace CSCore.SoundIn
 
                 if (Math.Max(buffer.Length - read, 0) < bytesAvailable && read > 0)
                 {
-                    RaiseDataAvilable(buffer, 0, read);
+                    RaiseDataAvailable(buffer, 0, read);
                     read = offset = 0;
                 }
 
@@ -338,7 +338,7 @@ namespace CSCore.SoundIn
                 nextPacketSize = captureClient.GetNextPacketSize();
             }
 
-            RaiseDataAvilable(buffer, 0, read);
+            RaiseDataAvailable(buffer, 0, read);
         }
 
         private void InitializeInternal()
@@ -400,7 +400,7 @@ namespace CSCore.SoundIn
             _audioCaptureClient = AudioCaptureClient.FromAudioClient(_audioClient);
         }
 
-        private void RaiseDataAvilable(byte[] buffer, int offset, int count)
+        private void RaiseDataAvailable(byte[] buffer, int offset, int count)
         {
             if (count <= 0)
                 return;


### PR DESCRIPTION
While reading through the `WasapiCapture` class to understand how it works I found a typo in the `RaiseDataAvailable` method (was `RaiseDataAvilable`).

Fixed throughout the entire class, recompiled the project without errors. Somehow I wasn't able to run the Unit tests, but since it's a private method, I don't suspect any trouble.