### PR TITLE
WaveWriter.Dispose fix

### DIFF
--- a/CSCore/Codecs/WAV/WaveWriter.cs
+++ b/CSCore/Codecs/WAV/WaveWriter.cs
@@ -49,7 +49,7 @@ namespace CSCore.Codecs.WAV
 
             _stream = stream;
             _waveStartPosition = stream.Position;
-	        _writer = new BinaryWriter(stream);
+            _writer = new BinaryWriter(stream);
             for (int i = 0; i < 44; i++)
             {
                 _writer.Write((byte) 0);
@@ -257,23 +257,23 @@ namespace CSCore.Codecs.WAV
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-			if (_writer != null)
-	        {
-				try
-				{
-					WriteHeader();
-				}
-				catch (Exception ex)
-				{
-					Debug.WriteLine("WaveWriter::Dispose: " + ex);
-				}
-				finally
-				{
-					_writer.Close();
-					_writer = null;
-					_stream = null;
-				}
-	        }
+            if (_writer != null)
+            {
+                try
+                {
+                    WriteHeader();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("WaveWriter::Dispose: " + ex);
+                }
+                finally
+                {
+                    _writer.Close();
+                    _writer = null;
+                    _stream = null;
+                }
+            }
         }
 
         /// <summary>

--- a/CSCore/Codecs/WAV/WaveWriter.cs
+++ b/CSCore/Codecs/WAV/WaveWriter.cs
@@ -14,7 +14,6 @@ namespace CSCore.Codecs.WAV
 
         private readonly long _waveStartPosition;
         private int _dataLength;
-        private bool _disposed;
         private Stream _stream;
         private BinaryWriter _writer;
 
@@ -50,7 +49,7 @@ namespace CSCore.Codecs.WAV
 
             _stream = stream;
             _waveStartPosition = stream.Position;
-            _writer = new BinaryWriter(stream);
+	        _writer = new BinaryWriter(stream);
             for (int i = 0; i < 44; i++)
             {
                 _writer.Write((byte) 0);
@@ -258,24 +257,23 @@ namespace CSCore.Codecs.WAV
         /// </param>
         protected virtual void Dispose(bool disposing)
         {
-            if (!_disposed)
-            {
-                try
-                {
-                    WriteHeader();
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine("WaveWriter::Dispose: " + ex);
-                }
-                finally
-                {
-                    _writer.Close();
-                    _writer = null;
-                    _stream = null;
-                }
-            }
-            _disposed = true;
+			if (_writer != null)
+	        {
+				try
+				{
+					WriteHeader();
+				}
+				catch (Exception ex)
+				{
+					Debug.WriteLine("WaveWriter::Dispose: " + ex);
+				}
+				finally
+				{
+					_writer.Close();
+					_writer = null;
+					_stream = null;
+				}
+	        }
         }
 
         /// <summary>


### PR DESCRIPTION
The _writer field could be null when the constructor that creates a stream threw an exception
