### PR TITLE
Thread-safed events, reduced allocations in DmoResampler

### DIFF
--- a/CSCore/DSP/DmoResampler.cs
+++ b/CSCore/DSP/DmoResampler.cs
@@ -18,6 +18,7 @@ namespace CSCore.DSP
         internal WMResampler Resampler;
         private bool _disposed;
         private int _quality = 30;
+        private byte[] readBuffer;
 
         private static WaveFormat GetWaveFormatWithChangedSampleRate(IWaveSource source, int destSampleRate)
         {
@@ -148,8 +149,8 @@ namespace CSCore.DSP
                     if (mediaObject.IsReadyForInput(0))
                     {
                         var bytesToRead = (int) OutputToInput(count - read);
-                        var inputData = new byte[bytesToRead];
-                        int bytesRead = base.Read(inputData, 0, inputData.Length);
+                        this.readBuffer = this.readBuffer.CheckBuffer(bytesToRead);
+                        int bytesRead = base.Read(this.readBuffer, 0, this.readBuffer.Length);
                         if (bytesRead <= 0)
                             break;
 
@@ -161,7 +162,7 @@ namespace CSCore.DSP
                             InputBuffer.Dispose();
                             InputBuffer = new MediaBuffer(bytesRead);
                         }
-                        InputBuffer.Write(inputData, 0, bytesRead);
+                        InputBuffer.Write(this.readBuffer, 0, bytesRead);
 
                         mediaObject.ProcessInput(0, InputBuffer);
 
@@ -237,6 +238,7 @@ namespace CSCore.DSP
             DisposeAndReset(ref Resampler);
             OutputBuffer.Dispose();
             DisposeAndReset(ref InputBuffer);
+            this.readBuffer = null;
 
             _disposed = true;
         }

--- a/CSCore/Streams/NotificationSource.cs
+++ b/CSCore/Streams/NotificationSource.cs
@@ -96,10 +96,11 @@ namespace CSCore.Streams
                 }
                 if (_buffer.Count >= BlockCount * WaveFormat.Channels)
                 {
-                    if (BlockRead != null)
+                    EventHandler<BlockReadEventArgs<float>> blockRead = this.BlockRead;
+                    if (blockRead != null)
                     {
                         float[] b = _buffer.ToArray();
-                        BlockRead(this, new BlockReadEventArgs<float>(b, b.Length));
+                        blockRead(this, new BlockReadEventArgs<float>(b, b.Length));
                         _buffer.Clear();
                     }
                 }

--- a/CSCore/Streams/SimpleNotificationSource.cs
+++ b/CSCore/Streams/SimpleNotificationSource.cs
@@ -91,22 +91,23 @@ namespace CSCore.Streams
             int read = base.Read(buffer, offset, count);
             int channels = WaveFormat.Channels;
 
-            if (BlockRead != null)
+            EventHandler blockRead = this.BlockRead;
+            if (blockRead != null)
             {
                 for (int i = 0; i < read / channels; i++)
                 {
                     _blocksRead++;
                     if (_blocksRead >= BlockCount)
                     {
-                        if (BlockRead != null)
-                            BlockRead(this, EventArgs.Empty);
+                        blockRead(this, EventArgs.Empty);
                         _blocksRead = 0;
                     }
                 }
             }
 
-            if (DataRead != null)
-                DataRead(this, EventArgs.Empty);
+            EventHandler dataRead = this.DataRead;
+            if (dataRead != null)
+                dataRead(this, EventArgs.Empty);
 
             return read;
         }

--- a/CSCore/Streams/SingleBlockNotificationStream.cs
+++ b/CSCore/Streams/SingleBlockNotificationStream.cs
@@ -44,12 +44,13 @@ namespace CSCore.Streams
         public override int Read(float[] buffer, int offset, int count)
         {
             int read = base.Read(buffer, offset, count);
-            if (read != 0 && SingleBlockRead != null)
+            EventHandler<SingleBlockReadEventArgs> singleBlockRead = this.SingleBlockRead;
+            if (read != 0 && singleBlockRead != null)
             {
                 int channels = WaveFormat.Channels;
                 for (int n = 0; n < read; n += channels)
                 {
-                    SingleBlockRead(this, new SingleBlockReadEventArgs(buffer, offset + n, channels));
+                    singleBlockRead(this, new SingleBlockReadEventArgs(buffer, offset + n, channels));
                 }
             }
 

--- a/CSCore/Streams/SoundInSource.cs
+++ b/CSCore/Streams/SoundInSource.cs
@@ -62,8 +62,9 @@ namespace CSCore.Streams
         private void OnDataAvailable(object sender, DataAvailableEventArgs e)
         {
             _buffer.Write(e.Data, 0, e.ByteCount);
-            if (e.ByteCount > 0 && DataAvailable != null)
-                DataAvailable(this, e);
+            EventHandler<DataAvailableEventArgs> dataAvailable = this.DataAvailable;
+            if (e.ByteCount > 0 && dataAvailable != null)
+                dataAvailable(this, e);
         }
 
         /// <summary>


### PR DESCRIPTION
1. StreamSources that were firing events were doing so in a non-thread-safe way. This has been fixed.
2. Every call to `DmoResampler.Read` allocates new `byte[]` arrays, causing lots of GC runs over the application lifetime. Using a class-scoped buffer array should fix the problem and yield some performance gains.
