### PR TITLE
Fix for ObjectDisposedException when disposing a voice after stopping

### DIFF
--- a/CSCore/XAudio2/StreamingSourceVoice.cs
+++ b/CSCore/XAudio2/StreamingSourceVoice.cs
@@ -107,7 +107,10 @@ namespace CSCore.XAudio2
             lock (_lockObj) //make sure that nothing gets disposed while anything is still in use.
             {
                 if (_disposed)
+                {
+                    _waitHandle.Close();
                     return;
+                }
 
                 int buffersQueued = GetState(GetVoiceStateFlags.NoSamplesPlayed).BuffersQueued;
                 if (buffersQueued >= MaxBufferCount)
@@ -151,7 +154,7 @@ namespace CSCore.XAudio2
                 if (_disposed)
                     return;
 
-                _waitHandle.Close();
+                _waitHandle.Reset();
                 Stop(SourceVoiceStopFlags.None, XAudio2.CommitNow);
 
                 foreach (XAudio2Buffer buffer in _buffers)


### PR DESCRIPTION
Disposing a StreamingSourceVoice instance, while the background thread is on the line below
`int index = WaitHandle.WaitAny(waitHandles, waitTimeout);`
in StreamingSourceVoiceListener.WorkerProc throws an ObjectDisposedException. The pull request reorders the operations to make sure the wait handle is disposed only after WaitAny exits.