### PR TITLE
CoreAudioAPIException now doesn't throw on S_FALSE

### DIFF
--- a/CSCore/CoreAudioAPI/CoreAudioAPIException.cs
+++ b/CSCore/CoreAudioAPI/CoreAudioAPIException.cs
@@ -11,14 +11,15 @@ namespace CSCore.CoreAudioAPI
     public class CoreAudioAPIException : Win32ComException
     {
         /// <summary>
-        /// Throws an <see cref="CoreAudioAPIException"/> if the <paramref name="result"/> is not <see cref="HResult.S_OK"/>.
+        /// Throws an <see cref="CoreAudioAPIException"/> if the <paramref name="result"/> represents an error.
         /// </summary>
-        /// <param name="result">Errorcode.</param>
+        /// <param name="result">The error code.</param>
         /// <param name="interfaceName">Name of the interface which contains the COM-function which returned the specified <paramref name="result"/>.</param>
         /// <param name="member">Name of the COM-function which returned the specified <paramref name="result"/>.</param>
         public new static void Try(int result, string interfaceName, string member)
         {
-            if (result != 0 && result != (int) Win32.HResult.AUDCLNT_S_BUFFER_EMPTY)
+            // < 0 means error, >= 0 means success
+            if (result < 0)
                 throw new CoreAudioAPIException(result, interfaceName, member);
         }
 

--- a/CSCore/DMO/DmoException.cs
+++ b/CSCore/DMO/DmoException.cs
@@ -48,7 +48,7 @@ namespace CSCore.DMO
         /// <param name="member">Name of the COM-function which returned the specified <paramref name="result" />.</param>
         public new static void Try(int result, string interfaceName, string member)
         {
-            if (result != 0)
+            if (result < 0)
                 throw new DmoException(result, interfaceName, member);
         }
 

--- a/CSCore/MediaFoundation/MediaFoundationException.cs
+++ b/CSCore/MediaFoundation/MediaFoundationException.cs
@@ -49,7 +49,7 @@ namespace CSCore.MediaFoundation
         /// <param name="member">Name of the COM-function which returned the specified <paramref name="result" />.</param>
         public new static void Try(int result, string interfaceName, string member)
         {
-            if (result != 0)
+            if (result < 0)
                 throw new MediaFoundationException(result, interfaceName, member);
         }
     }

--- a/CSCore/Win32/Win32ComException.cs
+++ b/CSCore/Win32/Win32ComException.cs
@@ -18,10 +18,9 @@ namespace CSCore.Win32
         /// <param name="result">Errorcode.</param>
         /// <param name="interfaceName">Name of the interface which contains the COM-function which returned the specified <paramref name="result"/>.</param>
         /// <param name="member">Name of the COM-function which returned the specified <paramref name="result"/>.</param>
-
         public static void Try(int result, string interfaceName, string member)
         {
-            if (result != 0)
+            if (result < 0)
                 throw new Win32ComException(result, interfaceName, member);
         }
 

--- a/CSCore/XAudio2/XAudio2Exception.cs
+++ b/CSCore/XAudio2/XAudio2Exception.cs
@@ -48,7 +48,7 @@ namespace CSCore.XAudio2
         /// <param name="member">Name of the COM-function which returned the specified <paramref name="result" />.</param>
         public new static void Try(int result, string interfaceName, string member)
         {
-            if (result != (int) Win32.HResult.S_OK)
+            if (result < 0)
                 throw new XAudio2Exception(result, interfaceName, member);
         }
     }


### PR DESCRIPTION
In some cases (see below) a `CoreAudioAPIException` with HResult 0x1 is thrown. 0x1 is _not_ an error code, so an Exception is not appropriate in this case.

This reproduces the error:
1. Create a `WasapiOut`
2. Pause Playback
3. Stop Playback

A `CoreAudioApiException` is thrown with HResult set to `0x1` respectively `S_FALSE` because the `AudioClient` has already been stopped. Throwing an Exception is false behaviour, since `S_FALSE` only indicates that no action has been taken because the client was already stopped.

(this is why it is recommended to use the `SUCCEEEDED` and `FAILED` macros in the WinAPI, they would have cought this case)