### PR TITLE
More thread-safing of events

### DIFF
--- a/CSCore/Codecs/FLAC/FlacPreScan.cs
+++ b/CSCore/Codecs/FLAC/FlacPreScan.cs
@@ -87,8 +87,9 @@ namespace CSCore.Codecs.FLAC
 
         private void RaiseScanFinished(List<FlacFrameInformation> frames)
         {
-            if (ScanFinished != null)
-                ScanFinished(this, new FlacPreScanFinishedEventArgs(frames));
+            EventHandler<FlacPreScanFinishedEventArgs> handler = this.ScanFinished;
+            if (handler != null)
+                handler(this, new FlacPreScanFinishedEventArgs(frames));
         }
 
         private unsafe List<FlacFrameInformation> ScanThisShit(FlacMetadataStreamInfo streamInfo)

--- a/CSCore/Codecs/MP3/Mp3WebStream.cs
+++ b/CSCore/Codecs/MP3/Mp3WebStream.cs
@@ -195,8 +195,9 @@ namespace CSCore.Codecs.MP3
 
                     success = resetEvent.WaitOne();
                 }
-                if (ConnectionEstablished != null && async)
-                    ConnectionEstablished(this, new ConnectionEstablishedEventArgs(_address, success));
+                EventHandler<ConnectionEstablishedEventArgs> handler = this.ConnectionEstablished;
+                if (handler != null && async)
+                    handler(this, new ConnectionEstablishedEventArgs(_address, success));
 
                 return success;
             };

--- a/CSCore/CoreAudioAPI/AudioEndpointVolumeCallback.cs
+++ b/CSCore/CoreAudioAPI/AudioEndpointVolumeCallback.cs
@@ -27,8 +27,9 @@ namespace CSCore.CoreAudioAPI
 
             var data =
                 (AudioVolumeNotificationData) Marshal.PtrToStructure(notifyData, typeof (AudioVolumeNotificationData));
-            if (NotifyRecived != null)
-                NotifyRecived(this, new AudioEndpointVolumeCallbackEventArgs(data, notifyData));
+            EventHandler<AudioEndpointVolumeCallbackEventArgs> handler = this.NotifyRecived;
+            if (handler != null)
+                handler(this, new AudioEndpointVolumeCallbackEventArgs(data, notifyData));
 
             return (int) HResult.S_OK;
         }

--- a/CSCore/CoreAudioAPI/AudioSessionEvents.cs
+++ b/CSCore/CoreAudioAPI/AudioSessionEvents.cs
@@ -53,8 +53,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnDisplayNameChanged(string newDisplayName, ref Guid eventContext)
         {
-            if (DisplayNameChanged != null)
-                DisplayNameChanged(this, new AudioSessionDisplayNameChangedEventArgs(newDisplayName, eventContext));
+            EventHandler<AudioSessionDisplayNameChangedEventArgs> handler = this.DisplayNameChanged;
+            if (handler != null)
+                handler(this, new AudioSessionDisplayNameChangedEventArgs(newDisplayName, eventContext));
             return (int) Win32.HResult.S_OK;
         }
 
@@ -66,8 +67,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnIconPathChanged(string newIconPath, ref Guid eventContext)
         {
-            if (IconPathChanged != null)
-                IconPathChanged(this, new AudioSessionIconPathChangedEventArgs(newIconPath, eventContext));
+            EventHandler<AudioSessionIconPathChangedEventArgs> handler = this.IconPathChanged;
+            if (handler != null)
+                handler(this, new AudioSessionIconPathChangedEventArgs(newIconPath, eventContext));
             return (int) Win32.HResult.S_OK;
         }
 
@@ -80,8 +82,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnSimpleVolumeChanged(float newVolume, bool newMute, ref Guid eventContext)
         {
-            if (SimpleVolumeChanged != null)
-                SimpleVolumeChanged(this, new AudioSessionSimpleVolumeChangedEventArgs(newVolume, newMute, eventContext));
+            EventHandler<AudioSessionSimpleVolumeChangedEventArgs> handler = this.SimpleVolumeChanged;
+            if (handler != null)
+                handler(this, new AudioSessionSimpleVolumeChangedEventArgs(newVolume, newMute, eventContext));
             return (int) Win32.HResult.S_OK;
         }
 
@@ -96,9 +99,10 @@ namespace CSCore.CoreAudioAPI
         int IAudioSessionEvents.OnChannelVolumeChanged(int channelCount, float[] newChannelVolumeArray,
             int changedChannel, ref Guid eventContext)
         {
-            if (ChannelVolumeChanged != null)
+            EventHandler<AudioSessionChannelVolumeChangedEventArgs> handler = this.ChannelVolumeChanged;
+            if (handler != null)
             {
-                ChannelVolumeChanged(this,
+                handler(this,
                     new AudioSessionChannelVolumeChangedEventArgs(channelCount, newChannelVolumeArray, changedChannel,
                         eventContext));
             }
@@ -113,8 +117,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnGroupingParamChanged(ref Guid newGroupingParam, ref Guid eventContext)
         {
-            if (GroupingParamChanged != null)
-                GroupingParamChanged(this, new AudioSessionGroupingParamChangedEventArgs(newGroupingParam, eventContext));
+            EventHandler<AudioSessionGroupingParamChangedEventArgs> handler = this.GroupingParamChanged;
+            if (handler != null)
+                handler(this, new AudioSessionGroupingParamChangedEventArgs(newGroupingParam, eventContext));
             return (int) Win32.HResult.S_OK;
         }
 
@@ -125,8 +130,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnStateChanged(AudioSessionState newState)
         {
-            if (StateChanged != null)
-                StateChanged(this, new AudioSessionStateChangedEventArgs(newState));
+            EventHandler<AudioSessionStateChangedEventArgs> handler = this.StateChanged;
+            if (handler != null)
+                handler(this, new AudioSessionStateChangedEventArgs(newState));
             return (int) Win32.HResult.S_OK;
         }
 
@@ -137,8 +143,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioSessionEvents.OnSessionDisconnected(AudioSessionDisconnectReason disconnectReason)
         {
-            if (SessionDisconnected != null)
-                SessionDisconnected(this, new AudioSessionDisconnectedEventArgs(disconnectReason));
+            EventHandler<AudioSessionDisconnectedEventArgs> handler = this.SessionDisconnected;
+            if (handler != null)
+                handler(this, new AudioSessionDisconnectedEventArgs(disconnectReason));
             return (int) Win32.HResult.S_OK;
         }
     }

--- a/CSCore/CoreAudioAPI/AudioVolumeDuckNotification.cs
+++ b/CSCore/CoreAudioAPI/AudioVolumeDuckNotification.cs
@@ -31,8 +31,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         int IAudioVolumeDuckNotification.OnVolumeDuckNotification(string sessionId, int countCommunicationSessions)
         {
-            if (VolumeDuckNotification != null)
-                VolumeDuckNotification(this, new VolumeDuckNotificationEventArgs(sessionId, countCommunicationSessions));
+            EventHandler<VolumeDuckNotificationEventArgs> handler = this.VolumeDuckNotification;
+            if (handler != null)
+                handler(this, new VolumeDuckNotificationEventArgs(sessionId, countCommunicationSessions));
             return (int) HResult.S_OK;
         }
 
@@ -44,9 +45,10 @@ namespace CSCore.CoreAudioAPI
         /// <returns></returns>
         int IAudioVolumeDuckNotification.OnVolumeUnduckNotification(string sessionId, int countCommunicationSessions)
         {
-            if (VolumeUnDuckNotification != null)
+            EventHandler<VolumeDuckNotificationEventArgs> handler = this.VolumeUnDuckNotification;
+            if (handler != null)
             {
-                VolumeUnDuckNotification(this,
+                handler(this,
                     new VolumeDuckNotificationEventArgs(sessionId, countCommunicationSessions));
             }
             return (int) HResult.S_OK;

--- a/CSCore/CoreAudioAPI/MMNotificationClient.cs
+++ b/CSCore/CoreAudioAPI/MMNotificationClient.cs
@@ -80,8 +80,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         void IMMNotificationClient.OnDeviceStateChanged(string deviceId, DeviceState deviceState)
         {
-            if (DeviceStateChanged != null)
-                DeviceStateChanged(this, new DeviceStateChangedEventArgs(deviceId, deviceState));
+            EventHandler<DeviceStateChangedEventArgs> handler = this.DeviceStateChanged;
+            if (handler != null)
+                handler(this, new DeviceStateChangedEventArgs(deviceId, deviceState));
 
             //return (int) HResult.S_OK;
         }
@@ -93,8 +94,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         void IMMNotificationClient.OnDeviceAdded(string deviceId)
         {
-            if (DeviceAdded != null)
-                DeviceAdded(this, new DeviceNotificationEventArgs(deviceId));
+            EventHandler<DeviceNotificationEventArgs> handler = this.DeviceAdded;
+            if (handler != null)
+                handler(this, new DeviceNotificationEventArgs(deviceId));
 
             //return (int) HResult.S_OK;
         }
@@ -106,8 +108,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         void IMMNotificationClient.OnDeviceRemoved(string deviceId)
         {
-            if (DeviceRemoved != null)
-                DeviceRemoved(this, new DeviceNotificationEventArgs(deviceId));
+            EventHandler<DeviceNotificationEventArgs> handler = this.DeviceRemoved;
+            if (handler != null)
+                handler(this, new DeviceNotificationEventArgs(deviceId));
 
             //return (int) HResult.S_OK;
         }
@@ -122,8 +125,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         void IMMNotificationClient.OnDefaultDeviceChanged(DataFlow dataFlow, Role role, string deviceId)
         {
-            if (DefaultDeviceChanged != null)
-                DefaultDeviceChanged(this, new DefaultDeviceChangedEventArgs(deviceId, dataFlow, role));
+            EventHandler<DefaultDeviceChangedEventArgs> handler = this.DefaultDeviceChanged;
+            if (handler != null)
+                handler(this, new DefaultDeviceChangedEventArgs(deviceId, dataFlow, role));
 
             //return (int) HResult.S_OK;
         }
@@ -137,8 +141,9 @@ namespace CSCore.CoreAudioAPI
         /// <returns>HRESULT</returns>
         void IMMNotificationClient.OnPropertyValueChanged(string deviceId, PropertyKey key)
         {
-            if (DevicePropertyChanged != null)
-                DevicePropertyChanged(this, new DevicePropertyChangedEventArgs(deviceId, key));
+            EventHandler<DevicePropertyChangedEventArgs> handler = this.DevicePropertyChanged;
+            if (handler != null)
+                handler(this, new DevicePropertyChangedEventArgs(deviceId, key));
 
             //return (int) HResult.S_OK;
         }

--- a/CSCore/SoundIn/WasapiCapture.cs
+++ b/CSCore/SoundIn/WasapiCapture.cs
@@ -404,25 +404,28 @@ namespace CSCore.SoundIn
         {
             if (count <= 0)
                 return;
-            if (DataAvailable != null)
+
+            EventHandler<DataAvailableEventArgs> handler = this.DataAvailable;
+            if (handler != null)
             {
                 var e = new DataAvailableEventArgs(buffer, offset, count, WaveFormat);
                 if (_synchronizationContext != null)
-                    _synchronizationContext.Post(o => DataAvailable(this, e), null); //use post instead of send to avoid deadlocks
+                    _synchronizationContext.Post(o => handler(this, e), null); //use post instead of send to avoid deadlocks
                 else
-                    DataAvailable(this, e);
+                    handler(this, e);
             }
         }
 
         private void RaiseStopped(Exception exception)
         {
-            if (Stopped != null)
+            EventHandler<RecordingStoppedEventArgs> handler = this.Stopped;
+            if (handler != null)
             {
                 var e = new RecordingStoppedEventArgs(exception);
                 if(_synchronizationContext != null)
-                    _synchronizationContext.Post(o => Stopped(this, e), null); //use post instead of send to avoid deadlocks
+                    _synchronizationContext.Post(o => handler(this, e), null); //use post instead of send to avoid deadlocks
                 else
-                    Stopped(this, e);
+                    handler(this, e);
             }
         }
 

--- a/CSCore/SoundIn/WaveIn.cs
+++ b/CSCore/SoundIn/WaveIn.cs
@@ -320,15 +320,17 @@ namespace CSCore.SoundIn
 
         private void RaiseStopped(Exception exception)
         {
-            if (Stopped != null)
-                Stopped(this, new RecordingStoppedEventArgs(exception));
+            EventHandler<RecordingStoppedEventArgs> handler = this.Stopped;
+            if (handler != null)
+                handler(this, new RecordingStoppedEventArgs(exception));
         }
 
         private void RaiseDataAvailable(WaveInBuffer buffer)
         {
-            if (DataAvailable != null && buffer.WaveHeader.bytesRecorded > 0)
+            EventHandler<DataAvailableEventArgs> handler = this.DataAvailable;
+            if (handler != null && buffer.WaveHeader.bytesRecorded > 0)
             {
-                DataAvailable(this,
+                handler(this,
                     new DataAvailableEventArgs(buffer.Buffer, 0, buffer.WaveHeader.bytesRecorded, WaveFormat));
             }
         }

--- a/CSCore/SoundOut/DirectSoundOut.cs
+++ b/CSCore/SoundOut/DirectSoundOut.cs
@@ -509,13 +509,13 @@ namespace CSCore.SoundOut
 
         private void RaiseStopped(Exception exception)
         {
-            if (Stopped == null)
-                return;
-
-            if (_syncContext != null)
-                _syncContext.Post(x => Stopped(this, new PlaybackStoppedEventArgs(exception)), null);
-            else
-                Stopped(this, new PlaybackStoppedEventArgs(exception));
+            EventHandler<PlaybackStoppedEventArgs> handler = this.Stopped;
+            if (handler != null) {
+                if (_syncContext != null)
+                    _syncContext.Post(x => handler(this, new PlaybackStoppedEventArgs(exception)), null);
+                else
+                    handler(this, new PlaybackStoppedEventArgs(exception));
+            }
         }
 
         private void CleanupResources()

--- a/CSCore/SoundOut/WasapiOut.cs
+++ b/CSCore/SoundOut/WasapiOut.cs
@@ -765,14 +765,14 @@ namespace CSCore.SoundOut
 
 		private void RaiseStopped(Exception exception)
 		{
-			if (Stopped == null)
-				return;
-
-			if (_syncContext != null)
-				//since Send could cause deadlocks better use Post instead
-				_syncContext.Post(x => Stopped(this, new PlaybackStoppedEventArgs(exception)), null);
-			else
-				Stopped(this, new PlaybackStoppedEventArgs(exception));
+            EventHandler<PlaybackStoppedEventArgs> handler = this.Stopped;
+            if (handler != null) {
+                if (_syncContext != null)
+                    //since Send could cause deadlocks better use Post instead
+                    _syncContext.Post(x => handler(this, new PlaybackStoppedEventArgs(exception)), null);
+                else
+                    handler(this, new PlaybackStoppedEventArgs(exception));
+            }
 		}
 
 		/// <summary>

--- a/CSCore/SoundOut/WaveOut.cs
+++ b/CSCore/SoundOut/WaveOut.cs
@@ -282,8 +282,9 @@ namespace CSCore.SoundOut
 
         private void RaiseStopped(Exception exception)
         {
-            if (Stopped != null)
-                Stopped(this, new PlaybackStoppedEventArgs(exception));
+            EventHandler<PlaybackStoppedEventArgs> handler = this.Stopped;
+            if (handler != null)
+                handler(this, new PlaybackStoppedEventArgs(exception));
         }
 
         private void CheckForIsInitialized()

--- a/CSCore/Streams/LoopStream.cs
+++ b/CSCore/Streams/LoopStream.cs
@@ -51,9 +51,10 @@ namespace CSCore.Streams
                 int r = base.Read(buffer, offset + read, count - read);
                 if (r == 0)
                 {
-                    if (StreamFinished != null && !_raisedStreamFinishedEvent)
+                    EventHandler handler = this.StreamFinished;
+                    if (handler != null && !_raisedStreamFinishedEvent)
                     {
-                        StreamFinished(this, EventArgs.Empty);
+                        handler(this, EventArgs.Empty);
                         _raisedStreamFinishedEvent = true;
                     }
 

--- a/CSCore/Streams/PeakMeter.cs
+++ b/CSCore/Streams/PeakMeter.cs
@@ -119,8 +119,9 @@ namespace CSCore.Streams
 
         private void RaisePeakCalculated()
         {
-            if (PeakCalculated != null)
-                PeakCalculated(this, new PeakEventArgs(ChannelPeakValues, PeakValue));
+            EventHandler<PeakEventArgs> handler = this.PeakCalculated;
+            if (handler != null)
+                handler(this, new PeakEventArgs(ChannelPeakValues, PeakValue));
         }
     }
 }

--- a/CSCore/XAudio2/VoiceCallback.cs
+++ b/CSCore/XAudio2/VoiceCallback.cs
@@ -12,44 +12,51 @@ namespace CSCore.XAudio2
     {
         void IXAudio2VoiceCallback.OnVoiceProcessingPassStart(int bytesRequired)
         {
-            if (ProcessingPassStart != null)
-                ProcessingPassStart(this, new XAudio2ProcessingPassStartEventArgs(bytesRequired));
+            EventHandler<XAudio2ProcessingPassStartEventArgs> handler = this.ProcessingPassStart;
+            if (handler != null)
+                handler(this, new XAudio2ProcessingPassStartEventArgs(bytesRequired));
         }
 
         void IXAudio2VoiceCallback.OnVoiceProcessingPassEnd()
         {
-            if (ProcessingPassEnd != null)
-                ProcessingPassEnd(this, EventArgs.Empty);
+            EventHandler handler = this.ProcessingPassEnd;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         void IXAudio2VoiceCallback.OnStreamEnd()
         {
-            if (StreamEnd != null)
-                StreamEnd(this, EventArgs.Empty);
+            EventHandler handler = this.StreamEnd;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         void IXAudio2VoiceCallback.OnBufferStart(IntPtr bufferContextPtr)
         {
-            if (BufferStart != null)
-                BufferStart(this, new XAudio2BufferEventArgs(bufferContextPtr));
+            EventHandler<XAudio2BufferEventArgs> handler = this.BufferStart;
+            if (handler != null)
+                handler(this, new XAudio2BufferEventArgs(bufferContextPtr));
         }
 
         void IXAudio2VoiceCallback.OnBufferEnd(IntPtr bufferContextPtr)
         {
-            if (BufferEnd != null)
-                BufferEnd(this, new XAudio2BufferEventArgs(bufferContextPtr));
+            EventHandler<XAudio2BufferEventArgs> handler = this.BufferEnd;
+            if (handler != null)
+                handler(this, new XAudio2BufferEventArgs(bufferContextPtr));
         }
 
         void IXAudio2VoiceCallback.OnLoopEnd(IntPtr bufferContextPtr)
         {
-            if (LoopEnd != null)
-                LoopEnd(this, new XAudio2BufferEventArgs(bufferContextPtr));
+            EventHandler<XAudio2BufferEventArgs> handler = this.LoopEnd;
+            if (handler != null)
+                handler(this, new XAudio2BufferEventArgs(bufferContextPtr));
         }
 
         void IXAudio2VoiceCallback.OnVoiceError(IntPtr bufferContextPtr, int error)
         {
-            if (VoiceError != null)
-                VoiceError(this, new XAudio2VoiceErrorEventArgs(bufferContextPtr, error));
+            EventHandler<XAudio2VoiceErrorEventArgs> handler = this.VoiceError;
+            if (handler != null)
+                handler(this, new XAudio2VoiceErrorEventArgs(bufferContextPtr, error));
         }
 
         /// <summary>

--- a/CSCore/XAudio2/XAudio2EngineCallback.cs
+++ b/CSCore/XAudio2/XAudio2EngineCallback.cs
@@ -11,20 +11,23 @@ namespace CSCore.XAudio2
     {
         void IXAudio2EngineCallback.OnProcessingPassStart()
         {
-            if (ProcessingPassStart != null)
-                ProcessingPassStart(this, EventArgs.Empty);
+            EventHandler handler = this.ProcessingPassStart;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         void IXAudio2EngineCallback.OnProcessingPassEnd()
         {
-            if (ProcessingPassEnd != null)
-                ProcessingPassEnd(this, EventArgs.Empty);
+            EventHandler handler = this.ProcessingPassEnd;
+            if (handler != null)
+                handler(this, EventArgs.Empty);
         }
 
         void IXAudio2EngineCallback.OnCriticalError(int error)
         {
-            if (CriticalError != null)
-                CriticalError(this, new XAudio2CriticalErrorEventArgs(error));
+            EventHandler<XAudio2CriticalErrorEventArgs> handler = this.CriticalError;
+            if (handler != null)
+                handler(this, new XAudio2CriticalErrorEventArgs(error));
         }
 
         /// <summary>


### PR DESCRIPTION
Today I got bitten by un-thread-safe event raising patterns that seem to be _everywhere_ inside CSCore. I tried to find and replace them with safer patterns.

I suggest reading http://stackoverflow.com/a/16216543/2000501 and https://blogs.msdn.microsoft.com/ericlippert/2009/04/29/events-and-races/