### PR TITLE
Optimized performance of VolumeSource

### DIFF
--- a/CSCore/Streams/VolumeSource.cs
+++ b/CSCore/Streams/VolumeSource.cs
@@ -7,6 +7,11 @@ namespace CSCore.Streams
     /// </summary>
     public class VolumeSource : SampleAggregatorBase
     {
+        /// <summary>
+        /// The epsilon which is used to compare for almost-equality of the volume in <see cref="Read(float[], int, int)"/>.
+        /// </summary>
+        private const float Epsilon = 0.0001f;
+
         private float _volume = 1f;
 
         /// <summary>
@@ -55,10 +60,18 @@ namespace CSCore.Streams
         public override int Read(float[] buffer, int offset, int count)
         {
             int read = base.Read(buffer, offset, count);
-
-            for (int i = offset; i < read + offset; i++)
+            
+            float volume = Volume;
+            if (volume == 0f || (volume > -Epsilon && volume < Epsilon)) 
             {
-                buffer[i] *= Volume;
+                Array.Clear(buffer, offset, read);
+            } 
+            else if (volume != 1f && !(volume > (1f - Epsilon) && volume < (1f + Epsilon))) 
+            {
+                for (int i = offset; i < read + offset; i++) 
+                {
+                    buffer[i] *= volume;
+                }
             }
 
             return read;

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ Some projects using already using cscore:
 - ...
 
 "CSCore - Visualization" Sample:
-
 ![VIS_SAMPLE](http://download-codeplex.sec.s-msft.com/Download?ProjectName=cscore&DownloadId=970569)
+
+"CSCoreWaveform" Sample:
+![WAVFRM_SAMPLE](http://fs5.directupload.net/images/160229/adjvd9u9.png)
 
 #### As long as this document is in development, see [Codeplex](http://cscore.codeplex.com/) for more details.  ####

--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ Some projects using already using cscore:
 - ...
 
 "CSCore - Visualization" Sample:
+
 ![VIS_SAMPLE](http://download-codeplex.sec.s-msft.com/Download?ProjectName=cscore&DownloadId=970569)
 
 "CSCoreWaveform" Sample:
+
 ![WAVFRM_SAMPLE](http://fs5.directupload.net/images/160229/adjvd9u9.png)
 
 #### As long as this document is in development, see [Codeplex](http://cscore.codeplex.com/) for more details.  ####


### PR DESCRIPTION
I noticed the performance of the `Volume-` and `GainSource` can be optimized be short-circuiting in special cases. It now falls back to Array.Clear (which should be faster than manual multiplication) if the volume is zero, and does not modify the read data at all, if the volume is 100% or very very close to it.