### PR TITLE
Some OpenAL Fixes

### DIFF
--- a/CSCore/SoundOut/AL/ALInterops.cs
+++ b/CSCore/SoundOut/AL/ALInterops.cs
@@ -68,7 +68,10 @@ namespace CSCore.SoundOut.AL
         [DllImport("OpenAL32.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourceStop(uint sourceId);
 
-        [DllImport("OpenAL32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void alSourceRewind(uint sourceId);
+
+        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourceQueueBuffers(uint sourceId, int number, uint[] bufferIDs);
 
         [DllImport("OpenAL32.dll", CallingConvention = CallingConvention.Cdecl)]

--- a/CSCore/SoundOut/AL/ALPlayback.cs
+++ b/CSCore/SoundOut/AL/ALPlayback.cs
@@ -73,18 +73,8 @@ namespace CSCore.SoundOut.AL
         /// </summary>
         /// <param name="stream">The stream</param>
         /// <param name="format">The format</param>
-        public void Initialize(IWaveSource stream, WaveFormat format)
-        {
-            Initialize(stream, format, 150);
-        }
-
-        /// <summary>
-        /// Initializes the openal playback
-        /// </summary>
-        /// <param name="stream">The stream</param>
-        /// <param name="format">The format</param>
         /// <param name="latency">The latency</param>
-        public void Initialize(IWaveSource stream, WaveFormat format, int latency)
+        public void Initialize(IWaveSource stream, WaveFormat format, int latency = 50)
         {
             _playbackStream = stream;
 			_waveFormat = stream.WaveFormat;

--- a/CSCore/SoundOut/AL/ALPlayback.cs
+++ b/CSCore/SoundOut/AL/ALPlayback.cs
@@ -1,6 +1,7 @@
 ﻿
 using System;
 using System.Threading;
+using System.Diagnostics;
 
 namespace CSCore.SoundOut.AL
 {
@@ -43,6 +44,8 @@ namespace CSCore.SoundOut.AL
         private WaveFormat _waveFormat;
         private int _bufferSize;
         private ALFormat _alFormat;
+        private uint[] _buffers;
+        private bool _stopPlaybackThread = false;
 
         /// <summary>
         /// Initializes a new ALPlayback class
@@ -95,14 +98,14 @@ namespace CSCore.SoundOut.AL
         /// </summary>
         public void Play()
         {
-            if (PlaybackState == PlaybackState.Stopped)
+            lock (_locker)
             {
-                _playbackThread = new Thread(PlaybackThread) {IsBackground = true};
-                _playbackThread.Start();
-            }
-            if (PlaybackState == PlaybackState.Paused)
-            {
-                lock (_locker)
+                if (PlaybackState == PlaybackState.Stopped)
+                {
+                    _playbackThread = new Thread(PlaybackThread) {IsBackground = true};
+                    _playbackThread.Start();
+                }
+                if (PlaybackState == PlaybackState.Paused)
                 {
                     Device.Context.MakeCurrent();
                     ALInterops.alSourcePlay(_source.Id);
@@ -119,10 +122,26 @@ namespace CSCore.SoundOut.AL
         {
             lock (_locker)
             {
+                // we signal to the playback thread to stop
+                _stopPlaybackThread = true;
+
                 Device.Context.MakeCurrent();
+
+                // Wait for the currently playing buffers to finish - this means that we can safely restart the source
+                WaitForBuffersToFinish();
+
                 ALInterops.alSourceStop(_source.Id);
                 PlaybackState = PlaybackState.Stopped;
                 RaisePlaybackChanged();
+
+                #if DEBUG
+                int buffersQueued;
+                ALInterops.alGetSourcei(_source.Id, ALSourceParameters.BuffersQueued, out buffersQueued);
+                Debug.WriteLine("Stopping source, " + buffersQueued + " buffers are still queued");
+                #endif
+
+                // reset the playback thread state
+                _stopPlaybackThread = false;
             }
         }
 
@@ -166,9 +185,16 @@ namespace CSCore.SoundOut.AL
 
             Device.Context.MakeCurrent();
 
-            var buffers = CreateBuffers(4);
+            // Create our buffers if they do not exist
+            if (_buffers == null)
+            {
+                _buffers = CreateBuffers(4);
+            }
 
-			FillBuffers(buffers);
+            // Fill the buffers - this fills all of them, which is safe because this method
+            // can only be called after WaitForBuffersToFinish(), which ensures that all
+            // our buffers are dequeued from the source
+            FillBuffers(_buffers);
 
             ALInterops.alSourcePlay(_source.Id);
 
@@ -176,6 +202,12 @@ namespace CSCore.SoundOut.AL
             {
                 while (_playbackStream.Position < _playbackStream.Length)
                 {
+                    if (_stopPlaybackThread) return;
+
+                    // get finished buffers so we can dequeue them
+                    int finishedBuffersAmount;
+                    ALInterops.alGetSourcei(_source.Id, ALSourceParameters.BuffersProcessed, out finishedBuffersAmount);
+
                     switch (PlaybackState)
                     {
                         case PlaybackState.Paused:
@@ -183,29 +215,32 @@ namespace CSCore.SoundOut.AL
                             continue;
                         case PlaybackState.Stopped:
                             return;
+                        case PlaybackState.Playing:
+                            // sleep if there are no buffers to queue
+                            if (finishedBuffersAmount == 0)
+                            {
+                                Thread.Sleep(Latency);
+                                continue;
+                            }
+
+                            var unqueuedBuffers = UnqueueBuffers(finishedBuffersAmount);
+
+                            // fill the unqueued buffers
+                            FillBuffers(unqueuedBuffers);
+
+                            // restart the source playing if it is stopped
+                            int sourceState;
+                            ALInterops.alGetSourcei(_source.Id, ALSourceParameters.SourceState, out sourceState);
+                            if ((ALSourceState)sourceState == ALSourceState.Stopped)
+                            {
+                                ALInterops.alSourcePlay(_source.Id);
+                            }
+
+                            break;
                     }
 
-                    int finishedBuffersAmount;
-                    ALInterops.alGetSourcei(_source.Id, ALSourceParameters.BuffersProcessed, out finishedBuffersAmount);
-
-                    if (finishedBuffersAmount == 0)
-                    {
-                        Thread.Sleep(Latency);
-                        continue;
-                    }
-
-					var unqueuedBuffers = UnqueueBuffers(finishedBuffersAmount);
-
-					FillBuffers(unqueuedBuffers);
-
+                    // update the position
                     Position = _playbackStream.Position / _waveFormat.BytesPerSecond * 1000;
-
-                    int sourceState;
-                    ALInterops.alGetSourcei(_source.Id, ALSourceParameters.SourceState, out sourceState);
-                    if ((ALSourceState)sourceState == ALSourceState.Stopped)
-                    {
-                        ALInterops.alSourcePlay(_source.Id);
-                    }
                 }
             }
             catch (Exception ex)
@@ -215,6 +250,31 @@ namespace CSCore.SoundOut.AL
 
             PlaybackState = PlaybackState.Stopped;
             RaisePlaybackChanged(exception);
+        }
+
+        private void WaitForBuffersToFinish()
+        {
+            while (true)
+            {
+                // get finished buffers so we can dequeue them
+                int finishedBuffersAmount;
+                ALInterops.alGetSourcei(_source.Id, ALSourceParameters.BuffersProcessed, out finishedBuffersAmount);
+
+                // dequeue buffers if there are any
+                UnqueueBuffers(finishedBuffersAmount);
+
+                // we need to wait for the currently queued buffers to finish
+                int queuedBuffers;
+                ALInterops.alGetSourcei(_source.Id, ALSourceParameters.BuffersQueued, out queuedBuffers);
+
+                if (queuedBuffers == 0)
+                {
+                    return;
+                } 
+
+                // Sleep if we are still waiting for buffers to finish
+                Thread.Sleep(10);
+            }
         }
 
         /// <summary>

--- a/CSCore/SoundOut/AL/ALPlayback.cs
+++ b/CSCore/SoundOut/AL/ALPlayback.cs
@@ -35,8 +35,9 @@ namespace CSCore.SoundOut.AL
         /// <summary>
         /// Raises when the playback state changed
         /// </summary>
-        public event EventHandler<EventArgs> PlaybackChanged; 
+        public event EventHandler<EventArgs> PlaybackChanged;
 
+        private const int BUFFER_COUNT = 4;
         private readonly ALSource _source;
         private Thread _playbackThread;
         private readonly object _locker;
@@ -188,7 +189,7 @@ namespace CSCore.SoundOut.AL
             // Create our buffers if they do not exist
             if (_buffers == null)
             {
-                _buffers = CreateBuffers(4);
+                _buffers = CreateBuffers(BUFFER_COUNT);
             }
 
             // Fill the buffers - this fills all of them, which is safe because this method

--- a/CSCore/SoundOut/ALSoundOut.cs
+++ b/CSCore/SoundOut/ALSoundOut.cs
@@ -48,6 +48,13 @@ namespace CSCore.SoundOut
 
         public event EventHandler<PlaybackStoppedEventArgs> Stopped;
 
+        /// <summary>
+        /// The latency of this <see cref="ALSoundOut"/> in ms
+        /// <para></para>
+        /// Note that the observed latency is <see cref="Latency"/> * NUMBER_OF_OPENAL_BUFFERS,
+        /// which is set to 4. So a <see cref="Latency"/> of 50 will produce an observed
+        /// latency of 200 ms.
+        /// </summary>
         public int Latency { get; set; }
 
         private ALPlayback _alPlayback;
@@ -55,21 +62,21 @@ namespace CSCore.SoundOut
         private readonly ALDevice _alDevice;
 
         /// <summary>
-        /// Initializes a new ALSoundOut class with the default device and a latency of 150 ms
+        /// Initializes a new ALSoundOut class with the default device and a latency of 50 ms
         /// </summary>
         public ALSoundOut() : this(ALDevice.DefaultDevice)
         {
         }
 
         /// <summary>
-        /// Initializes a new ALSoundOut class with a latency of 150 ms
+        /// Initializes a new ALSoundOut class with a latency of 50 ms
         /// </summary>
         /// <param name="device">The openal device</param>
         public ALSoundOut(ALDevice device)
         {
             _alDevice = device;
             _alDevice.Initialize();
-            Latency = 150;
+            Latency = 50;
         }
 
         ~ALSoundOut()


### PR DESCRIPTION
**Changes:**

* Fixed a bug where stopping an ALSoundOut and then restarting it would play some old buffers before starting the new ones.
The fix is to block once ALSoundOut is stopped until all buffers have finished playing and then they are dequeued. The code uses a WaitForBuffersToFinish method, similar to WaveOut.

* Adding a missing openal interop method, alSourceRewind.
* Use a constant for the number of OpenAL buffers used.
* Tidied up a method signature (ALPlayback.Initialize()) and added XML documentation to ALSoundOut.Latency.
* Reduced default latency to 50 ms.