### PR TITLE
Fixed a bug caused by the sleep time being 0 that made the CPU use

### DIFF
--- a/CSCore/SoundOut/WasapiOut.cs
+++ b/CSCore/SoundOut/WasapiOut.cs
@@ -432,7 +432,7 @@ namespace CSCore.SoundOut
                     else
                     {
                         //based on the "RenderSharedTimerDriven"-Sample: http://msdn.microsoft.com/en-us/library/dd940521(v=vs.85).aspx
-                        Thread.Sleep(_latency / 8);
+                        Thread.Sleep(_latency / 8 > 0 ? _latency / 8 : 1);
                     }
 
                     if (PlaybackState == PlaybackState.Playing)


### PR DESCRIPTION
spike to 100% load while PlaybackState is playing or paused.

The bug only affected some CPUs;
No issues on Athlon X2 II 265 and FX-6300
100 single core load (or ~12-13% on total load) on FX-8320