### PR TITLE
Use OpenAL itself instead of volumeSource to set gain

### DIFF
--- a/CSCore/SoundOut/AL/ALSource.cs
+++ b/CSCore/SoundOut/AL/ALSource.cs
@@ -54,6 +54,37 @@ namespace CSCore.SoundOut.AL
         }
 
         /// <summary>
+        /// Sets gain of <see cref="ALSource"/>.
+        /// </summary>
+        public float Gain
+        {
+            get
+            {
+                using (_context.LockContext())
+                {
+                    float gain = 1f;
+                    ALException.Try(
+                        () =>
+                            ALInterops.alGetSourcef(Id, ALSourceParameters.Gain, out gain),
+                        "alGetSourcef(gain)");
+                    return gain;
+                }
+            }
+
+            set
+            {
+                using (_context.LockContext())
+                {
+                    ALException.Try(
+                        () =>
+                            ALInterops.alSourcef(Id, ALSourceParameters.Gain, value),
+                        "alSourcef(gain)");
+                }
+            }
+
+        }
+
+        /// <summary>
         /// Pauses the <see cref="ALSource"/>.
         /// </summary>
         public void Pause()

--- a/CSCore/SoundOut/ALSoundOut.cs
+++ b/CSCore/SoundOut/ALSoundOut.cs
@@ -38,7 +38,6 @@ namespace CSCore.SoundOut
         private Thread _playbackThread;
         private ALDevice _playingDevice;
         private IWaveSource _source;
-        private VolumeSource _volumeSource;
         private ALContext _context;
 
         /// <summary>
@@ -139,12 +138,12 @@ namespace CSCore.SoundOut
         /// </summary>
         public float Volume
         {
-            get { return _volumeSource != null ? _volumeSource.Volume : 1; }
+            get { return _alSource != null ? _alSource.Gain : 1; }
             set
             {
                 CheckForDisposed();
                 CheckForIsInitialized();
-                _volumeSource.Volume = value;
+                _alSource.Gain = value;
             }
         }
 
@@ -327,10 +326,9 @@ namespace CSCore.SoundOut
                 _context = new ALContext(_playingDevice);
 
                 source = new InterruptDisposingChainSource(source);
-                _volumeSource = new VolumeSource(source.ToSampleSource());
 
                 int numberOfBitsPerSample = FindBestBitDepth(source.WaveFormat);
-                _source = _volumeSource.ToWaveSource(numberOfBitsPerSample);
+                _source = source.ToSampleSource().ToWaveSource(numberOfBitsPerSample);
 
                 InitializeInternal();
 


### PR DESCRIPTION
Just removed the usage of volumeSource to set the gain as OpenAL itself can be used for that.
Tested on a fork of Dopamine with a rebased CSCore to the newest version, seems to work fine with OpenAL Soft and a Creative X-Fi, also the perceived latency on volume change is a lot lower.

Any suggestion is greatly appreciated :)

By the way, is there any plan on merging your OpenAL branch to master? What is missing?