### PR TITLE
Corrected size of each buffer to respect latency setting

### DIFF
--- a/CSCore/SoundOut/ALSoundOut.cs
+++ b/CSCore/SoundOut/ALSoundOut.cs
@@ -468,7 +468,7 @@ namespace CSCore.SoundOut
                         ALInterops.alGenBuffers(_buffers.Length, _buffers),
                     "alGenBuffers");
             }
-            _bufferSize = (int)_source.WaveFormat.MillisecondsToBytes(_latency);
+            _bufferSize = (int)_source.WaveFormat.MillisecondsToBytes(_latency / NumberOfBuffers);
         }
 
         private void CleanupResources()


### PR DESCRIPTION
I did not know if I should have opened just an issue with a patch or a PR with the fix, but I chose the later.

The total OpenAL latency is the sum of the latency of all buffers, as most of the time all buffers are full.
So instead of creating each buffer with the size of the set latency we should split the latency between all buffers.
Before if the latency was set to 200 ms the actual latency would be 800 ms, now 200 ms is 200 ms.

This shouldn't make much difference playing music after PR# 263 as the volume won't be as late, but will make on actions that depend on buffered/decoder events (like visualizations) and on functions where syncing is needed.