### PR TITLE
Fix of waitHandle disposing

### DIFF
--- a/CSCore/Extensions.cs
+++ b/CSCore/Extensions.cs
@@ -419,9 +419,12 @@ namespace CSCore
 
             using (var waitHandle = new AutoResetEvent(false))
             {
-// ReSharper disable once AccessToDisposedClosure
-                soundOut.Stopped += (s, e) => waitHandle.Set();
-                return waitHandle.WaitOne(millisecondsTimeout);
+                EventHandler<PlaybackStoppedEventArgs> handler = (s, e) => waitHandle.Set();
+                soundOut.Stopped += handler;
+                bool result = waitHandle.WaitOne(millisecondsTimeout);
+                // need to unsubscrive because waitHandle will be disposed
+                soundOut.Stopped -= handler;
+                return result;
             }
         }
 


### PR DESCRIPTION
The program was crashing when trying to dispose ISoundOut after calling WaitForStopped with timeout (Resharper warned about AccessToDisposedClosure!)

This is the fix.