### PR TITLE
Override old data of buffer

### DIFF
--- a/CSCore/Utils/Buffer/FixedSizeBuffer.cs
+++ b/CSCore/Utils/Buffer/FixedSizeBuffer.cs
@@ -81,27 +81,28 @@ namespace CSCore.Utils.Buffer
         /// <returns>Number of added elements.</returns>
         public int Write(T[] buffer, int offset, int count)
         {
-            int written = 0;
+            var written = 0;
 
             lock (_lockObj)
             {
-                if (count > _buffer.Length - _bufferedElements)
-                    count = _buffer.Length - _bufferedElements;
+                var lastWrittenOffset = (_writeOffset + count - 1) % _buffer.Length;
+                var offset1 = Math.Max(lastWrittenOffset - count + 1, 0);
+                var length1 = lastWrittenOffset - offset1 + 1;
+                Array.Copy(buffer, offset + count - length1, _buffer, offset1, length1);
+                written += length1;
 
-                int length = Math.Min(count, _buffer.Length - _writeOffset);
-                Array.Copy(buffer, offset, _buffer, _writeOffset, length); //copy to buffer
-                _writeOffset += length;
-                written += length;
-                _writeOffset = _writeOffset % _buffer.Length;
-
-                if (written < count)
+                if (length1 < _buffer.Length && count > length1)
                 {
-                    Array.Copy(buffer, offset + written, _buffer, _writeOffset, count - written);
-                    _writeOffset += (count - written);
-                    written += (count - written);
+                    var remainedLength = count - length1;
+                    var offset2 = _buffer.Length - remainedLength <= lastWrittenOffset
+                        ? offset1 + 1
+                        : _buffer.Length - remainedLength;
+                    var length2 = _buffer.Length - offset2;
+                    Array.Copy(buffer, offset + count - length1 - length2, _buffer, offset2, length2);
+                    written += length2;
                 }
-
-                _bufferedElements += written;
+                _bufferedElements = Math.Min(_bufferedElements + written, _buffer.Length);
+                _writeOffset = (lastWrittenOffset + 1) % _buffer.Length;
             }
 
             return written;

--- a/CSCore/Utils/Buffer/FixedSizeBuffer.cs
+++ b/CSCore/Utils/Buffer/FixedSizeBuffer.cs
@@ -95,7 +95,7 @@ namespace CSCore.Utils.Buffer
                 {
                     var remainedLength = count - length1;
                     var offset2 = _buffer.Length - remainedLength <= lastWrittenOffset
-                        ? offset1 + 1
+                        ? lastWrittenOffset
                         : _buffer.Length - remainedLength;
                     var length2 = _buffer.Length - offset2;
                     Array.Copy(buffer, offset + count - length1 - length2, _buffer, offset2, length2);


### PR DESCRIPTION
Relative Issue : #306

# What I did
Override old data of buffer

# Why?
Because `WriteableBufferingSource` must override old data by its description above constructor.

# How?
I just override data even if buffered amount is fulled. (previous version don't copy more if buffered amount is equal to buffer size!)
And also, I copied data from back, not from front to avoid unnecessary copy if the input data is longer than our buffer.

# Is it important?
Yes. because the comment you give to users is a kind of promise. we should provide the function in right way.

### Please check the variable's name because I have no idea about variable name. It's sucks, offset1, offset2.. omg...