### PR TITLE
Made _activeBuffers volatile within the WaveOut class. 

### DIFF
--- a/CSCore/SoundOut/WaveOut.cs
+++ b/CSCore/SoundOut/WaveOut.cs
@@ -17,7 +17,7 @@ namespace CSCore.SoundOut
         private readonly WaveCallback _callback;
         private readonly Queue<int> _failedBuffers = new Queue<int>();
         private readonly object _lockObject = new object();
-        private int _activeBuffers;
+        private volatile int _activeBuffers;
         private WaveOutBuffer[] _buffers;
         private Thread _callbackThread;
         private WaveOutDevice _device;
@@ -465,7 +465,6 @@ namespace CSCore.SoundOut
 
         private void WaitForBuffersToFinish()
         {
-            //do we have volatile to _activeBuffers???
             while (Interlocked.CompareExchange(ref _activeBuffers, 0, 0) != 0 && PlaybackState != PlaybackState.Stopped)
             {
                 Thread.Sleep(10);


### PR DESCRIPTION
After significant testing of this audio class with multiple threads, I found that the "Stop" method of the "WaveOut" class would sometimes not return and my thread would be stuck on that call. After further investigation, I found the root cause was the thread was stuck in a hard loop on the "WaitForBuffersToFinish" method. There was a comment within that method about whether or not the _activeBuffers  should be volatile. I believe it should be since I am using multiple threads.

So, I made _activeBuffers volatile and it fixed my issue. 