### PR TITLE
Workaround for AL interop on Linux

### DIFF
--- a/CSCore/CSCore.csproj
+++ b/CSCore/CSCore.csproj
@@ -15,6 +15,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+    <DefineConstants>WINDOWS</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/CSCore/SoundOut/AL/ALInterops.cs
+++ b/CSCore/SoundOut/AL/ALInterops.cs
@@ -8,132 +8,138 @@ namespace CSCore.SoundOut.AL
     [CLSCompliant(false)]
     internal class ALInterops
     {
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        #if WINDOWS
+            private const string libLocation = "openal32.dll";
+        #else
+            private const string libLocation = "libopenal";
+       #endif
+
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alGetString(int name);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcGetString([In] IntPtr device, int name);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern sbyte alcIsExtensionPresent([In] IntPtr device, string extensionName);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern sbyte alIsExtensionPresent(string extensionName);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcCaptureStart(IntPtr device);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcCaptureStop(IntPtr device);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcCaptureSamples(IntPtr device, IntPtr buffer, int numSamples);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcCaptureOpenDevice(string deviceName, uint frequency, ALFormat format,
             int bufferSize);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcCaptureCloseDevice(IntPtr device);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcOpenDevice(string deviceName);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool alcCloseDevice(IntPtr handle);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcCreateContext(IntPtr device, IntPtr attrlist);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern bool alcMakeContextCurrent(IntPtr context);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcGetContextsDevice(IntPtr context);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern IntPtr alcGetCurrentContext();
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alcDestroyContext(IntPtr context);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetSourcei(uint sourceId, ALSourceParameters param, out int value);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourcePlay(uint sourceId);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourcePause(uint sourceId);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourceStop(uint sourceId);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourceQueueBuffers(uint sourceId, int number, uint[] bufferIDs);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourceUnqueueBuffers(uint sourceId, int buffers, uint[] buffersDequeued);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGenSources(int count, uint[] sources);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alDeleteSources(int count, uint[] sources);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetSourcef(uint sourceId, ALSourceParameters param, out float value);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetSource3f(uint sourceId, ALSourceParameters param, out float val1,
             out float val2, out float val3);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourcef(uint sourceId, ALSourceParameters param, float value);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourcefv(uint sourceId, ALSourceParameters param, float[] value);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSource3f(uint sourceId, ALSourceParameters param, float val1, float val2,
             float val3);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alSourcei(uint sourceId, ALSourceParameters param, float val1);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGenBuffers(int count, uint[] bufferIDs);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alBufferData(uint bufferId, ALFormat format, byte[] data, int byteSize,
             uint frequency);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alDeleteBuffers(int numBuffers, uint[] bufferIDs);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alListenerf(ALSourceParameters param, float val);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alListenerfv(ALSourceParameters param, float[] val);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alListener3f(ALSourceParameters param, float val1, float val2, float val3);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetListener3f(ALSourceParameters param, out float val1, out float val2,
             out float val3);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetListenerf(ALSourceParameters param, out float val);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern void alGetListenerfv(ALSourceParameters param, float[] val);
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ALErrorCode alGetError();
 
-        [DllImport("openal32.dll", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(libLocation, CallingConvention = CallingConvention.Cdecl)]
         internal static extern ALErrorCode alcGetError(IntPtr handle);
 
         public const int DeviceSpecifier = 0x1005;


### PR DESCRIPTION
This fix makes ALSoundOut work on both Linux and Windows.

Admittedly, it's not an ideal solution, but since the path for DllImport has to be constant, I couldn't really find a better way to do it.